### PR TITLE
update base response, update orders to support new fields

### DIFF
--- a/prime_sdk/accept_quote.py
+++ b/prime_sdk/accept_quote.py
@@ -44,4 +44,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/accept_quote"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return AcceptQuoteResponse(response.json())
+        return AcceptQuoteResponse(**response.json())

--- a/prime_sdk/cancel_entity_futures_sweep.py
+++ b/prime_sdk/cancel_entity_futures_sweep.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def cancel_entity_futures_sweep(self, request: CancelEntityFuturesSweepRequest) -> CancelEntityFuturesSweepResponse:
         path = f"/entities/{request.entity_id}/futures/sweeps"
         response = self.client.request("DELETE", path, allowed_status_codes=request.allowed_status_codes)
-        return CancelEntityFuturesSweepResponse(response.json())
+        return CancelEntityFuturesSweepResponse(**response.json())

--- a/prime_sdk/cancel_order.py
+++ b/prime_sdk/cancel_order.py
@@ -38,4 +38,4 @@ class PrimeClient:
     def cancel_order(self, request: CancelOrderRequest) -> CancelOrderResponse:
         path = f"/portfolios/{request.portfolio_id}/orders/{request.order_id}/cancel"
         response = self.client.request("POST", path, allowed_status_codes=request.allowed_status_codes)
-        return CancelOrderResponse(response.json())
+        return CancelOrderResponse(**response.json())

--- a/prime_sdk/create_address_book_entry.py
+++ b/prime_sdk/create_address_book_entry.py
@@ -45,4 +45,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/address_book"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateAddressBookEntryResponse(response.json())
+        return CreateAddressBookEntryResponse(**response.json())

--- a/prime_sdk/create_conversion.py
+++ b/prime_sdk/create_conversion.py
@@ -51,4 +51,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/conversion"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateConversionResponse(response.json())
+        return CreateConversionResponse(**response.json())

--- a/prime_sdk/create_new_locates.py
+++ b/prime_sdk/create_new_locates.py
@@ -41,4 +41,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/locates"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateNewLocateResponse(response.json())
+        return CreateNewLocateResponse(**response.json())

--- a/prime_sdk/create_onchain_address_book_entry.py
+++ b/prime_sdk/create_onchain_address_book_entry.py
@@ -42,4 +42,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/onchain_address_group"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateOnchainAddressBookEntryResponse(response.json())
+        return CreateOnchainAddressBookEntryResponse(**response.json())

--- a/prime_sdk/create_onchain_transaction.py
+++ b/prime_sdk/create_onchain_transaction.py
@@ -56,4 +56,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/onchain_transaction"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateOnchainTransactionResponse(response.json())
+        return CreateOnchainTransactionResponse(**response.json())

--- a/prime_sdk/create_order.py
+++ b/prime_sdk/create_order.py
@@ -38,6 +38,9 @@ class CreateOrderRequest:
     display_base_size: Optional[str] = None
     is_raise_exact: Optional[str] = None
     historical_pov: Optional[str] = None
+    stop_price: Optional[str] = None
+    settl_currency: Optional[str] = None
+    post_only: Optional[bool] = None
     allowed_status_codes: Optional[List[int]] = None
 
 
@@ -54,4 +57,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/order"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateOrderResponse(response.json())
+        return CreateOrderResponse(**response.json())

--- a/prime_sdk/create_order_preview.py
+++ b/prime_sdk/create_order_preview.py
@@ -35,8 +35,11 @@ class CreateOrderPreviewRequest:
     stp_id: Optional[str] = None
     display_quote_size: Optional[str] = None
     display_base_size: Optional[str] = None
-    is_raise_exact: Optional[str] = None
+    is_raise_exact: Optional[bool] = None
     historical_pov: Optional[str] = None
+    stop_price: Optional[str] = None
+    settl_currency: Optional[str] = None
+    post_only: Optional[bool] = None
     allowed_status_codes: Optional[List[int]] = None
 
 
@@ -59,6 +62,11 @@ class CreateOrderPreviewResponse(BaseResponse):
     average_filled_price: str = None
     order_total: str = None
     historical_pov: str = None
+    stop_price: str = None
+    display_size: str = None
+    is_raise_exact: bool = None
+    settl_currency: str = None
+    post_only: bool = None
 
 
 class PrimeClient:
@@ -69,4 +77,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/order_preview"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateOrderPreviewResponse(response.json())
+        return CreateOrderPreviewResponse(**response.json())

--- a/prime_sdk/create_portfolio_allocations.py
+++ b/prime_sdk/create_portfolio_allocations.py
@@ -23,10 +23,10 @@ from warnings import warn
 
 @dataclass
 class AllocationLeg:
-    leg_id: Optional[str] = None
     allocation_leg_id: str
     destination_portfolio_id: str
     amount: str
+    leg_id: Optional[str] = None
     allowed_status_codes: Optional[List[int]] = None
 
     def __post_init__(self):
@@ -68,4 +68,4 @@ class PrimeClient:
             body["allocation_legs"] = [asdict(leg) for leg in request.allocation_legs]
 
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreatePortfolioAllocationsResponse(response.json(), request)
+        return CreatePortfolioAllocationsResponse(**response.json())

--- a/prime_sdk/create_portfolio_net_allocations.py
+++ b/prime_sdk/create_portfolio_net_allocations.py
@@ -61,4 +61,4 @@ class PrimeClient:
             body["allocation_legs"] = [asdict(leg) for leg in request.allocation_legs]
 
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreatePortfolioNetAllocationsResponse(response.json())
+        return CreatePortfolioNetAllocationsResponse(**response.json())

--- a/prime_sdk/create_quote.py
+++ b/prime_sdk/create_quote.py
@@ -49,4 +49,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/rfq"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateQuoteResponse(response.json())
+        return CreateQuoteResponse(**response.json())

--- a/prime_sdk/create_stake.py
+++ b/prime_sdk/create_stake.py
@@ -52,4 +52,4 @@ class PrimeClient:
             body["inputs"] = asdict(request.inputs)
 
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateStakeResponse(response.json())
+        return CreateStakeResponse(**response.json())

--- a/prime_sdk/create_transfer.py
+++ b/prime_sdk/create_transfer.py
@@ -52,4 +52,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/transfers"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateTransferResponse(response.json())
+        return CreateTransferResponse(**response.json())

--- a/prime_sdk/create_unstake.py
+++ b/prime_sdk/create_unstake.py
@@ -52,4 +52,4 @@ class PrimeClient:
             body["inputs"] = asdict(request.inputs)
 
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateUnstakeResponse(response.json())
+        return CreateUnstakeResponse(**response.json())

--- a/prime_sdk/create_wallet.py
+++ b/prime_sdk/create_wallet.py
@@ -46,4 +46,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/wallets"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateWalletResponse(response.json())
+        return CreateWalletResponse(**response.json())

--- a/prime_sdk/create_wallet_address.py
+++ b/prime_sdk/create_wallet_address.py
@@ -43,4 +43,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/addresses"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateWalletAddressResponse(response.json())
+        return CreateWalletAddressResponse(**response.json())

--- a/prime_sdk/create_withdrawal.py
+++ b/prime_sdk/create_withdrawal.py
@@ -75,4 +75,4 @@ class PrimeClient:
             body["blockchain_address"] = asdict(request.blockchain_address)
 
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return CreateWithdrawalResponse(response.json())
+        return CreateWithdrawalResponse(**response.json())

--- a/prime_sdk/delete_onchain_address_group.py
+++ b/prime_sdk/delete_onchain_address_group.py
@@ -40,4 +40,4 @@ class PrimeClient:
     def delete_onchain_address_group(self, request: DeleteOnchainAddressGroupRequest) -> DeleteOnchainAddressGroupResponse:
         path = f"/portfolios/{request.portfolio_id}/onchain_address_group/{request.address_group_id}"
         response = self.client.request("DELETE", path, allowed_status_codes=request.allowed_status_codes)
-        return DeleteOnchainAddressGroupResponse(response.json())
+        return DeleteOnchainAddressGroupResponse(**response.json())

--- a/prime_sdk/get_activity.py
+++ b/prime_sdk/get_activity.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_activity(self, request: GetActivityRequest) -> GetActivityResponse:
         path = f"/portfolios/{request.portfolio_id}/activities/{request.activity_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetActivityResponse(response.json())
+        return GetActivityResponse(**response.json())

--- a/prime_sdk/get_address_book.py
+++ b/prime_sdk/get_address_book.py
@@ -47,4 +47,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return GetAddressBookResponse(response.json())
+        return GetAddressBookResponse(**response.json())

--- a/prime_sdk/get_allocation_by_id.py
+++ b/prime_sdk/get_allocation_by_id.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_allocation_by_id(self, request: GetAllocationByIdRequest) -> GetAllocationByIdResponse:
         path = f"/portfolios/{request.portfolio_id}/allocations/{request.allocation_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetAllocationByIdResponse(response.json())
+        return GetAllocationByIdResponse(**response.json())

--- a/prime_sdk/get_entity_activity.py
+++ b/prime_sdk/get_entity_activity.py
@@ -38,4 +38,4 @@ class PrimeClient:
     def get_entity_activity_by_activity_id(self, request: GetEntityActivityRequest) -> GetEntityActivityResponse:
         path = f"/activities/{request.activity_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetEntityActivityResponse(response.json())
+        return GetEntityActivityResponse(**response.json())

--- a/prime_sdk/get_entity_fcm_balance.py
+++ b/prime_sdk/get_entity_fcm_balance.py
@@ -46,4 +46,4 @@ class PrimeClient:
     def get_entity_fcm_balance(self, request: GetEntityFcmBalanceRequest) -> GetEntityFcmBalanceResponse:
         path = f"/entities/{request.entity_id}/futures/balance_summary"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetEntityFcmBalanceResponse(response.json())
+        return GetEntityFcmBalanceResponse(**response.json())

--- a/prime_sdk/get_entity_locate_availabilities.py
+++ b/prime_sdk/get_entity_locate_availabilities.py
@@ -41,4 +41,4 @@ class PrimeClient:
         path = f"/entities/{request.entity_id}/locates_availability"
         query_params = append_query_param("", "locate_date", request.locate_date)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return GetEntityLocateAvailabilitiesResponse(response.json())
+        return GetEntityLocateAvailabilitiesResponse(**response.json())

--- a/prime_sdk/get_entity_payment_method.py
+++ b/prime_sdk/get_entity_payment_method.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_entity_payment_method(self, request: GetEntityPaymentMethodRequest) -> GetEntityPaymentMethodResponse:
         path = f"/entities/{request.entity_id}/payment-methods/{request.payment_method_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetEntityPaymentMethodResponse(response.json())
+        return GetEntityPaymentMethodResponse(**response.json())

--- a/prime_sdk/get_entity_positions.py
+++ b/prime_sdk/get_entity_positions.py
@@ -43,4 +43,4 @@ class PrimeClient:
         path = f"/entities/{request.entity_id}/futures/positions"
         query_params = append_query_param("", 'product_id', request.product_id)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return GetEntityPositionsResponse(response.json())
+        return GetEntityPositionsResponse(**response.json())

--- a/prime_sdk/get_margin_information.py
+++ b/prime_sdk/get_margin_information.py
@@ -38,4 +38,4 @@ class PrimeClient:
     def get_margin_information(self, request: GetMarginInformationRequest) -> GetMarginInformationResponse:
         path = f"/entities/{request.entity_id}/margin"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetMarginInformationResponse(response.json())
+        return GetMarginInformationResponse(**response.json())

--- a/prime_sdk/get_net_allocations_by_netting_id.py
+++ b/prime_sdk/get_net_allocations_by_netting_id.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_net_allocations_by_netting_id(self, request: GetNetAllocationsByNettingIdRequest) -> GetNetAllocationsByNettingIdResponse:
         path = f"/portfolios/{request.portfolio_id}/allocations/net/{request.netting_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetNetAllocationsByNettingIdResponse(response.json())
+        return GetNetAllocationsByNettingIdResponse(**response.json())

--- a/prime_sdk/get_order.py
+++ b/prime_sdk/get_order.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_order(self, request: GetOrderRequest) -> GetOrderResponse:
         path = f"/portfolios/{request.portfolio_id}/orders/{request.order_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetOrderResponse(response.json())
+        return GetOrderResponse(**response.json())

--- a/prime_sdk/get_portfolio.py
+++ b/prime_sdk/get_portfolio.py
@@ -38,4 +38,4 @@ class PrimeClient:
     def get_portfolio(self, request: GetPortfolioRequest) -> GetPortfolioResponse:
         path = f"/portfolios/{request.portfolio_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetPortfolioResponse(response.json())
+        return GetPortfolioResponse(**response.json())

--- a/prime_sdk/get_portfolio_buying_power.py
+++ b/prime_sdk/get_portfolio_buying_power.py
@@ -43,4 +43,4 @@ class PrimeClient:
         query_params = append_query_param("", "base_currency", request.base_currency)
         query_params = append_query_param(query_params, "quote_currency", request.quote_currency)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return GetBuyingPowerResponse(response.json())
+        return GetBuyingPowerResponse(**response.json())

--- a/prime_sdk/get_portfolio_commission.py
+++ b/prime_sdk/get_portfolio_commission.py
@@ -38,4 +38,4 @@ class PrimeClient:
     def get_portfolio_commission(self, request: GetPortfolioCommissionRequest) -> GetPortfolioCommissionResponse:
         path = f"/portfolios/{request.portfolio_id}/commission"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetPortfolioCommissionResponse(response.json(), request)
+        return GetPortfolioCommissionResponse(**response.json())

--- a/prime_sdk/get_portfolio_credit_information.py
+++ b/prime_sdk/get_portfolio_credit_information.py
@@ -38,4 +38,4 @@ class PrimeClient:
     def get_portfolio_credit_information(self, request: GetPortfolioCreditInformationRequest) -> GetPortfolioCreditInformationResponse:
         path = f"/portfolios/{request.portfolio_id}/credit"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetPortfolioCreditInformationResponse(response.json())
+        return GetPortfolioCreditInformationResponse(**response.json())

--- a/prime_sdk/get_portfolio_withdrawal_power.py
+++ b/prime_sdk/get_portfolio_withdrawal_power.py
@@ -41,4 +41,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/withdrawal_power"
         query_params = append_query_param("", "symbol", request.symbol)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return GetPortfolioWithdrawalPowerResponse(response.json())
+        return GetPortfolioWithdrawalPowerResponse(**response.json())

--- a/prime_sdk/get_trade_finance_tiered_pricing_fees.py
+++ b/prime_sdk/get_trade_finance_tiered_pricing_fees.py
@@ -41,4 +41,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/tf_tiered_fees"
         query_params = append_query_param("", "effective_at", request.effective_at)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return GetTradeFinanceTieredPricingFeesResponse(response.json())
+        return GetTradeFinanceTieredPricingFeesResponse(**response.json())

--- a/prime_sdk/get_transaction.py
+++ b/prime_sdk/get_transaction.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_transaction(self, request: GetTransactionRequest) -> GetTransactionResponse:
         path = f"/portfolios/{request.portfolio_id}/transactions/{request.transaction_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetTransactionResponse(response.json())
+        return GetTransactionResponse(**response.json())

--- a/prime_sdk/get_wallet.py
+++ b/prime_sdk/get_wallet.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_wallet(self, request: GetWalletRequest) -> GetWalletResponse:
         path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetWalletResponse(response.json())
+        return GetWalletResponse(**response.json())

--- a/prime_sdk/get_wallet_balance.py
+++ b/prime_sdk/get_wallet_balance.py
@@ -39,4 +39,4 @@ class PrimeClient:
     def get_wallet_balance(self, request: GetWalletBalanceRequest) -> GetWalletBalanceResponse:
         path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/balance"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return GetWalletBalanceResponse(response.json())
+        return GetWalletBalanceResponse(**response.json())

--- a/prime_sdk/get_wallet_deposit_instructions.py
+++ b/prime_sdk/get_wallet_deposit_instructions.py
@@ -43,4 +43,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/deposit_instructions"
         query_params = append_query_param("", 'deposit_type', request.deposit_type)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return GetWalletDepositInstructionsResponse(response.json())
+        return GetWalletDepositInstructionsResponse(**response.json())

--- a/prime_sdk/list_activities.py
+++ b/prime_sdk/list_activities.py
@@ -64,4 +64,4 @@ class PrimeClient:
 
         query_params = append_pagination_params(query_params, request.pagination)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListActivitiesResponse(response.json())
+        return ListActivitiesResponse(**response.json())

--- a/prime_sdk/list_aggregate_entity_positions.py
+++ b/prime_sdk/list_aggregate_entity_positions.py
@@ -42,4 +42,4 @@ class PrimeClient:
         path = f"/entities/{request.entity_id}/aggregate_positions"
         query_params = append_pagination_params(query_params, request.pagination)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListAggregateEntityPositionsResponse(response.json())
+        return ListAggregateEntityPositionsResponse(**response.json())

--- a/prime_sdk/list_assets.py
+++ b/prime_sdk/list_assets.py
@@ -37,4 +37,4 @@ class PrimeClient:
     def list_assets(self, request: ListAssetsRequest) -> ListAssetsResponse:
         path = f"/entities/{request.entity_id}/assets"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return ListAssetsResponse(response.json())
+        return ListAssetsResponse(**response.json())

--- a/prime_sdk/list_entity_activities.py
+++ b/prime_sdk/list_entity_activities.py
@@ -68,4 +68,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListEntityActivitiesResponse(response.json())
+        return ListEntityActivitiesResponse(**response.json())

--- a/prime_sdk/list_entity_balances.py
+++ b/prime_sdk/list_entity_balances.py
@@ -17,7 +17,7 @@ from typing import Optional, List
 from prime_sdk.base_response import BaseResponse
 from prime_sdk.client import Client
 from prime_sdk.credentials import Credentials
-from prime_sdk.model import Balance
+from prime_sdk.model import EntityBalance
 from prime_sdk.utils import append_query_param, Pagination, PaginationParams
 from prime_sdk.enums import AggregationType
 
@@ -33,7 +33,7 @@ class ListEntityBalancesRequest:
 
 @dataclass
 class ListEntityBalancesResponse(BaseResponse):
-    balances: List[Balance] = None
+    balances: List[EntityBalance] = None
     pagination: Pagination = None
 
 
@@ -47,4 +47,4 @@ class PrimeClient:
         query_params = append_query_param(query_params, "balance_type", request.balance_type)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListEntityBalancesResponse(response.json())
+        return ListEntityBalancesResponse(**response.json())

--- a/prime_sdk/list_entity_futures_sweeps.py
+++ b/prime_sdk/list_entity_futures_sweeps.py
@@ -40,4 +40,4 @@ class PrimeClient:
     def list_entity_futures_sweeps(self, request: ListEntityFuturesSweepsRequest) -> ListEntityFuturesSweepsResponse:
         path = f"/entities/{request.entity_id}/futures/sweeps"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return ListEntityFuturesSweepsResponse(response.json())
+        return ListEntityFuturesSweepsResponse(**response.json())

--- a/prime_sdk/list_entity_payment_methods.py
+++ b/prime_sdk/list_entity_payment_methods.py
@@ -43,4 +43,4 @@ class PrimeClient:
         query_params = append_pagination_params("", request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListEntityPaymentMethodsResponse(response.json())
+        return ListEntityPaymentMethodsResponse(**response.json())

--- a/prime_sdk/list_entity_positions.py
+++ b/prime_sdk/list_entity_positions.py
@@ -42,4 +42,4 @@ class PrimeClient:
         path = f"/entities/{request.entity_id}/positions"
         query_params = append_pagination_params("", request.pagination)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListEntityPositionsResponse(response.json())
+        return ListEntityPositionsResponse(**response.json())

--- a/prime_sdk/list_existing_locates.py
+++ b/prime_sdk/list_existing_locates.py
@@ -43,4 +43,4 @@ class PrimeClient:
         query_params = append_query_param("", "locate_ids", request.locate_ids)
         query_params = append_query_param(query_params, "locate_date", request.locate_date)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListExistingLocatesResponse(response.json())
+        return ListExistingLocatesResponse(**response.json())

--- a/prime_sdk/list_interest_accruals.py
+++ b/prime_sdk/list_interest_accruals.py
@@ -46,4 +46,4 @@ class PrimeClient:
         query_params = append_query_param(query_params, "start_date", request.start_date)
         query_params = append_query_param(query_params, "end_date", request.end_date)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListInterestAccrualsResponse(response.json())
+        return ListInterestAccrualsResponse(**response.json())

--- a/prime_sdk/list_interest_accruals_for_portfolio.py
+++ b/prime_sdk/list_interest_accruals_for_portfolio.py
@@ -45,4 +45,4 @@ class PrimeClient:
         query_params = append_query_param(query_params, "start_date", request.start_date)
         query_params = append_query_param(query_params, "end_date", request.end_date)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListInterestAccrualsForPortfolioResponse(response.json())
+        return ListInterestAccrualsForPortfolioResponse(**response.json())

--- a/prime_sdk/list_invoices.py
+++ b/prime_sdk/list_invoices.py
@@ -47,4 +47,4 @@ class PrimeClient:
         query_params = append_query_param(query_params, 'billing_month', request.billing_month)
         query_params = append_pagination_params(query_params, request.pagination)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListInvoicesResponse(response.json())
+        return ListInvoicesResponse(**response.json())

--- a/prime_sdk/list_margin_call_summaries.py
+++ b/prime_sdk/list_margin_call_summaries.py
@@ -43,4 +43,4 @@ class PrimeClient:
         query_params = append_query_param("", "start_date", request.start_date)
         query_params = append_query_param(query_params, "end_date", request.end_date)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListMarginCallSummariesResponse(response.json())
+        return ListMarginCallSummariesResponse(**response.json())

--- a/prime_sdk/list_margin_conversions.py
+++ b/prime_sdk/list_margin_conversions.py
@@ -43,4 +43,4 @@ class PrimeClient:
         query_params = append_query_param("", "start_date", request.start_date)
         query_params = append_query_param(query_params, "end_date", request.end_date)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListMarginConversionsResponse(response.json())
+        return ListMarginConversionsResponse(**response.json())

--- a/prime_sdk/list_onchain_address_groups.py
+++ b/prime_sdk/list_onchain_address_groups.py
@@ -38,4 +38,4 @@ class PrimeClient:
     def list_onchain_address_groups(self, request: ListOnchainAddressGroupsRequest) -> ListOnchainAddressGroupsResponse:
         path = f"/portfolios/{request.portfolio_id}/onchain_address_groups"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return ListOnchainAddressGroupsResponse(response.json())
+        return ListOnchainAddressGroupsResponse(**response.json())

--- a/prime_sdk/list_open_orders.py
+++ b/prime_sdk/list_open_orders.py
@@ -63,4 +63,4 @@ class PrimeClient:
                 request.end_date.isoformat() + 'Z')
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListOpenOrdersResponse(response.json(), request)
+        return ListOpenOrdersResponse(**response.json())

--- a/prime_sdk/list_order_fills.py
+++ b/prime_sdk/list_order_fills.py
@@ -45,4 +45,4 @@ class PrimeClient:
         query_params = append_pagination_params("", request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListOrderFillsResponse(response.json())
+        return ListOrderFillsResponse(**response.json())

--- a/prime_sdk/list_orders.py
+++ b/prime_sdk/list_orders.py
@@ -62,4 +62,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListOrdersResponse(response.json())
+        return ListOrdersResponse(**response.json())

--- a/prime_sdk/list_portfolio_allocations.py
+++ b/prime_sdk/list_portfolio_allocations.py
@@ -58,4 +58,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListPortfolioAllocationsResponse(response.json())
+        return ListPortfolioAllocationsResponse(**response.json())

--- a/prime_sdk/list_portfolio_balances.py
+++ b/prime_sdk/list_portfolio_balances.py
@@ -20,6 +20,9 @@ from prime_sdk.credentials import Credentials
 from prime_sdk.enums import BalanceType
 from prime_sdk.utils import PaginationParams, append_query_param, append_pagination_params
 from prime_sdk.model import Balance, BalanceWithHolds
+from dataclasses import asdict
+import dataclasses
+import json
 
 
 @dataclass
@@ -52,4 +55,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListPortfolioBalancesResponse(response.json(), request)
+        return ListPortfolioBalancesResponse(**response.json())

--- a/prime_sdk/list_portfolio_fills.py
+++ b/prime_sdk/list_portfolio_fills.py
@@ -52,4 +52,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListPortfolioFillsResponse(response.json())
+        return ListPortfolioFillsResponse(**response.json())

--- a/prime_sdk/list_portfolio_transactions.py
+++ b/prime_sdk/list_portfolio_transactions.py
@@ -56,4 +56,4 @@ class PrimeClient:
 
         query_params = append_pagination_params(query_params, request.pagination)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListPortfolioTransactionsResponse(response.json())
+        return ListPortfolioTransactionsResponse(**response.json())

--- a/prime_sdk/list_portfolio_users.py
+++ b/prime_sdk/list_portfolio_users.py
@@ -44,4 +44,4 @@ class PrimeClient:
         query_params = append_pagination_params("", request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListPortfolioUsersResponse(response.json())
+        return ListPortfolioUsersResponse(**response.json())

--- a/prime_sdk/list_portfolios.py
+++ b/prime_sdk/list_portfolios.py
@@ -37,4 +37,4 @@ class PrimeClient:
     def list_portfolios(self, request: ListPortfoliosRequest) -> ListPortfoliosResponse:
         path = "/portfolios"
         response = self.client.request("GET", path, allowed_status_codes=request.allowed_status_codes)
-        return ListPortfoliosResponse(response.json())
+        return ListPortfoliosResponse(**response.json())

--- a/prime_sdk/list_products.py
+++ b/prime_sdk/list_products.py
@@ -42,4 +42,4 @@ class PrimeClient:
 
         query_params = append_pagination_params("", request.pagination)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListProductsResponse(response.json())
+        return ListProductsResponse(**response.json())

--- a/prime_sdk/list_users.py
+++ b/prime_sdk/list_users.py
@@ -42,4 +42,4 @@ class PrimeClient:
         path = f"/entities/{request.entity_id}/users"
         query_params = append_pagination_params("", request.pagination)
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListUsersResponse(response.json())
+        return ListUsersResponse(**response.json())

--- a/prime_sdk/list_wallet_addresses.py
+++ b/prime_sdk/list_wallet_addresses.py
@@ -48,4 +48,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListWalletAddressesResponse(response.json())
+        return ListWalletAddressesResponse(**response.json())

--- a/prime_sdk/list_wallet_transactions.py
+++ b/prime_sdk/list_wallet_transactions.py
@@ -58,4 +58,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListWalletTransactionsResponse(response.json())
+        return ListWalletTransactionsResponse(**response.json())

--- a/prime_sdk/list_wallets.py
+++ b/prime_sdk/list_wallets.py
@@ -50,4 +50,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListWalletsResponse(response.json())
+        return ListWalletsResponse(**response.json())

--- a/prime_sdk/list_web3_wallet_balances.py
+++ b/prime_sdk/list_web3_wallet_balances.py
@@ -47,4 +47,4 @@ class PrimeClient:
         query_params = append_pagination_params(query_params, request.pagination)
 
         response = self.client.request("GET", path, query=query_params, allowed_status_codes=request.allowed_status_codes)
-        return ListWeb3WalletBalancesResponse(response.json(), request)
+        return ListWeb3WalletBalancesResponse(**response.json())

--- a/prime_sdk/model.py
+++ b/prime_sdk/model.py
@@ -220,6 +220,17 @@ class Position:
 
 
 @dataclass
+class OrderEditHistory:
+    price: str
+    size: str
+    display_size: str
+    stop_price: str
+    stop_limit_price: str
+    end_time: str
+    accept_time: str
+
+
+@dataclass
 class Order:
     id: str
     user_id: str
@@ -246,6 +257,11 @@ class Order:
     net_average_filled_price: str
     user_context: str
     client_product_id: str
+    post_only: bool = None
+    order_edit_history: List[OrderEditHistory] = None
+    is_raise_exact: bool = None
+    display_size: str = None
+    edit_history: List[OrderEditHistory] = None
 
 
 @dataclass
@@ -481,6 +497,8 @@ class Fill:
     time: str
     commission: str
     venue: str
+    venue_fees: str = None
+    ces_commission: str = None
 
 
 @dataclass
@@ -723,7 +741,7 @@ class MarginSummaryRecord:
 
 
 @dataclass
-class Balance:
+class EntityBalance:
     symbol: str
     long_amount: str
     long_notional: str
@@ -794,3 +812,17 @@ class PostTradeCredit:
 class Fee:
     symbol: str
     fee: str
+
+
+@dataclass
+class WalletAddress:
+    address: str
+    account_identifier: str
+    network: Network
+
+
+@dataclass
+class BlockchainAddress:
+    address: str
+    account_identifier: str
+    network: Network

--- a/prime_sdk/schedule_entity_futures_sweep.py
+++ b/prime_sdk/schedule_entity_futures_sweep.py
@@ -42,4 +42,4 @@ class PrimeClient:
         path = f"/entities/{request.entity_id}/futures/sweeps"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return ScheduleEntityFuturesSweepResponse(response.json())
+        return ScheduleEntityFuturesSweepResponse(**response.json())

--- a/prime_sdk/set_auto_sweep.py
+++ b/prime_sdk/set_auto_sweep.py
@@ -40,4 +40,4 @@ class PrimeClient:
         path = f"/entities/{request.entity_id}/futures/auto_sweep"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return SetAutoSweepResponse(response.json())
+        return SetAutoSweepResponse(**response.json())

--- a/prime_sdk/update_onchain_address_book.py
+++ b/prime_sdk/update_onchain_address_book.py
@@ -42,4 +42,4 @@ class PrimeClient:
         path = f"/portfolios/{request.portfolio_id}/onchain_address_group"
         body = {k: v for k, v in asdict(request).items() if v is not None}
         response = self.client.request("PUT", path, body=body, allowed_status_codes=request.allowed_status_codes)
-        return UpdateOnchainAddressBookResponse(response.json(), request)
+        return UpdateOnchainAddressBookResponse(**response.json())

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="prime-sdk-py",
-    version="0.4.1",
+    version="0.4.2",
     packages=find_packages(),
     install_requires=[
         'requests',


### PR DESCRIPTION
- Refactored BaseResponse to initialize directly from dataclass fields using **response.json() instead of wrapping the response in a dictionary. This change simplifies object creation and makes the response behave like a standard dataclass.
- Added support for additional trading fields
- Corrected bug where the Portfolio Balance dataclass was being overwritten