### PR TITLE
Fix: Correct endpoint path for create_conversion API

### DIFF
--- a/prime_sdk/services/transactions/service.py
+++ b/prime_sdk/services/transactions/service.py
@@ -49,7 +49,7 @@ class TransactionsService:
         self.client = client
 
     def create_conversion(self, request: CreateConversionRequest) -> CreateConversionResponse:
-        path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/conversions"
+        path = f"/portfolios/{request.portfolio_id}/wallets/{request.wallet_id}/conversion"
         body = to_body_dict(request)
         response = self.client.request("POST", path, body=body, allowed_status_codes=request.allowed_status_codes)
         return CreateConversionResponse(**response.json())


### PR DESCRIPTION
## Summary
This PR fixes a bug in the `create_conversion` endpoint path that was causing 404 errors.

## Problem
The SDK was using `/portfolios/{portfolio_id}/wallets/{wallet_id}/conversions` (plural) but the API documentation specifies `/portfolios/{portfolio_id}/wallets/{wallet_id}/conversion` (singular).

## Solution
Changed the endpoint path from `/conversions` to `/conversion` to match the API documentation.

## Testing
Tested and confirmed working with USD <> USDC conversions on a live Coinbase Prime portfolio.

## References
- [Coinbase Prime API Documentation - Create Conversion](https://docs.cdp.coinbase.com/api-reference/prime-api/rest-api/transactions/create-conversion)
- Per documentation: `POST /v1/portfolios/{portfolio_id}/wallets/{wallet_id}/conversion`